### PR TITLE
Forgotten $ on depth variable

### DIFF
--- a/uikit-menu-walker.php
+++ b/uikit-menu-walker.php
@@ -67,7 +67,7 @@ class Walker_UIKIT extends Walker {
         $indent = str_repeat("\t", $depth);
         $output.= "$indent</ul>\n";
         
-        if ($this->has_children && depth == 0) {
+        if ($this->has_children && $depth == 0) {
 
             $indent = "\t$indent";
             $output.= "$indent</div>\n";


### PR DESCRIPTION
A $ was forgotten on the depth variable. This was causing a `<div>` to not
be closed which was causing w3 validation to fail all over the place.
